### PR TITLE
chore: update dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "friday"
       time: "00:30"
     target-branch: "master"
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "friday"
       time: "00:30"
     target-branch: "master"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/terraform/cloudflare"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "friday"
       time: "00:30"
     target-branch: "master"


### PR DESCRIPTION
Update dependabot schedule from weekly (every Friday) to monthly (first Friday of each month).